### PR TITLE
Add logic to handle multiple genres and -zsh revenue/budget values

### DIFF
--- a/src/components/Description/Description.js
+++ b/src/components/Description/Description.js
@@ -15,11 +15,15 @@ const Description = (selectedMovie) => {
         <p className="label">Overview:</p>
         <p>{overview}</p>
       </div>
-      <p><span className="label">Genre(s):</span> {genre}</p>
+      <p><span className="label">Genre(s):</span> {genre.join('-')}</p>
       <p><span className="label">Released:</span> {releaseDate}</p>
       <p><span className="label">Runtime:</span>  {runtime} mins.</p>
-      <p><span className="label">Budget:</span>  ${(budget / 1000000).toFixed(2)} m.</p>
-      <p><span className="label">Revenue:</span>  ${(revenue / 1000000).toFixed(2)} m.</p>
+      {budget > 0 &&
+        <p><span className="label">Budget:</span>  ${(budget / 1000000).toFixed(2)} m.</p>
+      }
+      {revenue > 0 &&
+        <p><span className="label">Revenue:</span>  ${(revenue / 1000000).toFixed(2)} m.</p>
+      }
     </article>
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Joins multiple genres with a dash, if there are more than one.
- Adds logic to conditionally render budget and revenue elements if their values are greater than $0.

## How should it be tested in the UI?

- cd into Rancid-Tomatillos repo, run npm start
- Click on the 'Rogue' movie card (as it has zero values for revenue and budget), and the description area should not display revenue or budget lines.
- Click on the 'Mulan' movie card, and the description area should reflect revenue and budget, as both of these values were returned in the API call.