### PR TITLE
Update fetch protocol to from http to https to meet Heroku dependency

### DIFF
--- a/cypress/integration/rancid-tomatillos-test.js
+++ b/cypress/integration/rancid-tomatillos-test.js
@@ -120,7 +120,7 @@ describe('App Sad Paths', () => {
   it('should reveal an error message when the server returns a 404 status code', () => {
     cy.intercept({
       method: 'GET',
-      url: 'http://rancid-tomatillos.herokuapp.com/api/v2/movies'
+      url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
     },
     {
       statusCode: 404
@@ -133,7 +133,7 @@ describe('App Sad Paths', () => {
   it('should reveal an error message when the server returns a 500 status code', () => {
     cy.intercept({
       method: 'GET',
-      url: 'http://rancid-tomatillos.herokuapp.com/api/v2/movies'
+      url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
     },
     {
       statusCode: 500
@@ -146,7 +146,7 @@ describe('App Sad Paths', () => {
   it('should reveal an error message when the server returns a 404 status code', () => {
     cy.intercept({
       method: 'GET',
-      url: 'http://rancid-tomatillos.herokuapp.com/api/v2/movies/337401'
+      url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401'
     },
     {
       statusCode: 404
@@ -159,7 +159,7 @@ describe('App Sad Paths', () => {
   it('should reveal an error message when the server returns a 500 status code', () => {
     cy.intercept({
       method: 'GET',
-      url: 'http://rancid-tomatillos.herokuapp.com/api/v2/movies/337401'
+      url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401'
     },
     {
       statusCode: 500

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -1,5 +1,5 @@
 
 export const testAPI = (path) => {
- return fetch(`http://rancid-tomatillos.herokuapp.com/api/v2/${path}`)
+ return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/${path}`)
           .then((response) => response.json())
 }


### PR DESCRIPTION
## What does this PR do?

- Updates fetch request URL in app and tests to use HTTPS protocol. HTTP was used previously (and worked without issue), but Heroku deployment requires HTTPS.

## How should it be tested in the UI?

- Full regression test
